### PR TITLE
update phpunit and pollyfiles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "phpstan/phpstan": "^1.0",
         "szepeviktor/phpstan-wordpress": "^1.0",
         "php-stubs/wordpress-stubs": "6.2.*",
@@ -31,7 +31,7 @@
         "wp-phpunit/wp-phpunit": "6.2.*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*",
-        "yoast/phpunit-polyfills": "^1.0.0",
+        "yoast/phpunit-polyfills": "^1.0.0 || ^2.0.0",
         "symfony/var-dumper": "*",
         "gin0115/wpunit-helpers": "~1",
         "vlucas/phpdotenv": "^5.4"


### PR DESCRIPTION
This pull request updates the development dependencies in the `composer.json` file to support newer versions of PHPUnit and Yoast PHPUnit Polyfills. This ensures better compatibility with more recent testing frameworks and polyfill packages.

Testing framework compatibility:

* Updated the `phpunit/phpunit` requirement to allow both version 8 and 9, enabling use of newer PHPUnit features and compatibility.
* Updated the `yoast/phpunit-polyfills` requirement to allow both version 1 and 2, ensuring compatibility with newer polyfill releases.