### PR TITLE
docs: note #32 fix in 2.1.1 changelog entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ public function seed_on_inital_activation(): bool {
 ```
 
 ## Change Log
-* 2.1.1 - Updated dev dependencies.
+* 2.1.1 - Updated dev dependencies. Migration_Exception now surfaces the underlying DI failure reason (closes #32).
 * 2.1.0 - Update dependencies to support Perique V2.1
 * 2.0.0 - Support for Perique V2.*
 * 1.0.0 - Initial Release (Supports Perique V1.2-1.4)


### PR DESCRIPTION
This pull request updates the changelog to clarify that in version 2.1.1, the `Migration_Exception` now surfaces the underlying dependency injection (DI) failure reason, addressing issue #32.