### PR TITLE
feat: add up()/down() lifecycle hooks on Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,59 @@ public function seed_on_inital_activation(): bool {
 }
 ```
 
+***
+> ### up(): void
+> @return void
+
+Lifecycle hook fired on every activation, **after** the table has been upserted and **before** any seed data is inserted. Default implementation is a no-op — override it when you need to run custom SQL (for example an `ALTER` to add a column introduced by a newer plugin version) or any other post-upsert work.
+
+> Because `up()` fires on **every** activation rather than just first install, implementations MUST be idempotent. Guard your work so running it twice has no effect.
+
+The canonical use case is shipping a new Migration class in a later plugin version whose job is to evolve a table owned by an earlier migration:
+
+```php
+class Add_Email_To_Users_Migration extends Migration {
+
+    protected function table_name(): string {
+        return 'my_users'; // same table as the original migration
+    }
+
+    public function schema( Schema $schema_config ): void {
+        // No-op schema: the original migration already defines the table.
+    }
+
+    public function up(): void {
+        global $wpdb;
+
+        // Idempotency guard: only add the column if it's not there yet.
+        $has_email = $wpdb->get_var( $wpdb->prepare(
+            'SELECT COUNT(*) FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND COLUMN_NAME = %s',
+            DB_NAME, 'my_users', 'email'
+        ) );
+
+        if ( (int) $has_email === 0 ) {
+            $wpdb->query( 'ALTER TABLE my_users ADD COLUMN email VARCHAR(255) NULL' );
+        }
+    }
+}
+```
+
+***
+> ### down(): void
+> @return void
+
+Lifecycle hook fired just **before** the migration's table is dropped by the Deactivation or Uninstall event handlers. Only called for migrations that are actually being dropped — i.e. `drop_on_deactivation()` or `drop_on_uninstall()` returned `TRUE`. Migrations that stay in place do not have `down()` called. Default implementation is a no-op — override it to perform custom teardown (export rows elsewhere, emit an audit hook, etc.) while the table still exists.
+
+```php
+public function down(): void {
+    // Called right before the table is dropped.
+    // Use this for last-chance teardown while the table is still readable.
+}
+```
+
 ## Change Log
+* 2.2.0 - Add `up()` and `down()` lifecycle hooks on `Migration` for post-upsert work and pre-drop teardown. Uninstall cleanup now wraps drop + log removal in try/finally so a stale migration log can't outlive a failed drop.
 * 2.1.1 - Updated dev dependencies. Migration_Exception now surfaces the underlying DI failure reason (closes #32).
 * 2.1.0 - Update dependencies to support Perique V2.1
 * 2.0.0 - Support for Perique V2.*

--- a/src/Event/Activation.php
+++ b/src/Event/Activation.php
@@ -36,7 +36,23 @@ class Activation implements State_Events_Activation {
 	 */
 	public function run(): void {
 		$this->upsert_tables();
+		$this->run_up_hooks();
 		$this->seed_tables();
+	}
+
+	/**
+	 * Fire the up() hook on every registered migration, after the schema has
+	 * been upserted and before seeding. Implementations of up() must be
+	 * idempotent; see Migration::up().
+	 *
+	 * @return void
+	 */
+	private function run_up_hooks(): void {
+		/** @var Migration[] $migrations */
+		$migrations = $this->migration_manager->get_migrations();
+		foreach ( $migrations as $migration ) {
+			$migration->up();
+		}
 	}
 
 	/**

--- a/src/Event/Deactivation.php
+++ b/src/Event/Deactivation.php
@@ -35,7 +35,26 @@ class Deactivation implements State_Events_Deactivation {
 	 * @return void
 	 */
 	public function run(): void {
+		$this->run_down_hooks();
 		$this->drop_tables();
+	}
+
+	/**
+	 * Fire the down() hook on each migration flagged to be dropped on
+	 * deactivation, before the table is actually dropped so the hook can
+	 * still read from it. Migrations where drop_on_deactivation() is false
+	 * are left alone and their down() is not called.
+	 *
+	 * @return void
+	 */
+	private function run_down_hooks(): void {
+		/** @var Migration[] $migrations */
+		$migrations = $this->migration_manager->get_migrations();
+		foreach ( $migrations as $migration ) {
+			if ( $migration->drop_on_deactivation() ) {
+				$migration->down();
+			}
+		}
 	}
 
 	/**

--- a/src/Event/Uninstall.php
+++ b/src/Event/Uninstall.php
@@ -66,6 +66,11 @@ class Uninstall implements State_Events_Uninstall {
 	/**
 	 * Runs the dropping of all valid tables.
 	 *
+	 * The down() hooks and the table drops run inside a try block; the
+	 * migration log is removed in the finally so it is always cleaned up,
+	 * even if a drop fails part-way through, so a subsequent reinstall
+	 * starts from a clean manifest.
+	 *
 	 * @return void
 	 */
 	public function run(): void {
@@ -74,8 +79,28 @@ class Uninstall implements State_Events_Uninstall {
 			return;
 		}
 
-		$this->remove_migration_log();
-		$this->drop_tables();
+		try {
+			$this->run_down_hooks();
+			$this->drop_tables();
+		} finally {
+			$this->remove_migration_log();
+		}
+	}
+
+	/**
+	 * Fire the down() hook on each migration flagged for drop-on-uninstall,
+	 * before the table is actually dropped so the hook can still read from
+	 * it. $this->tables has already been filtered to just the migrations
+	 * with drop_on_uninstall() === true.
+	 *
+	 * @return void
+	 */
+	private function run_down_hooks(): void {
+		foreach ( $this->tables as $migration ) {
+			if ( $migration instanceof Migration ) {
+				$migration->down();
+			}
+		}
 	}
 
 	/**
@@ -85,8 +110,8 @@ class Uninstall implements State_Events_Uninstall {
 	 */
 	protected function drop_tables() {
 		/**
- * @var \wpdb $wpdb
-*/
+		 * @var \wpdb $wpdb
+		*/
 		global $wpdb;
 
 		// Temp disable warnings.

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -70,4 +70,30 @@ abstract class Migration extends Database_Migration {
 	public function seed_on_inital_activation(): bool {
 		return true;
 	}
+
+	/**
+	 * Hook fired on every activation, after the table has been upserted and
+	 * before it is seeded. Default implementation is a no-op; override it to
+	 * run custom SQL (e.g. ALTER statements on an existing table installed by
+	 * an earlier migration) or any other post-upsert work.
+	 *
+	 * Implementations MUST be idempotent — this method fires on every
+	 * activation, not just on first install.
+	 *
+	 * @return void
+	 */
+	public function up(): void {
+	}
+
+	/**
+	 * Hook fired just before the migration's table is dropped by the
+	 * Deactivation or Uninstall event handlers. Only called for migrations
+	 * that are actually being dropped (i.e. drop_on_deactivation() or
+	 * drop_on_uninstall() returned true). Default implementation is a no-op;
+	 * override it to perform custom teardown while the table still exists.
+	 *
+	 * @return void
+	 */
+	public function down(): void {
+	}
 }

--- a/tests/Fixtures/Alter_First_Table_Via_Up_Migration.php
+++ b/tests/Fixtures/Alter_First_Table_Via_Up_Migration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture for the "second migration alters first" integration scenario.
+ * Has its own tiny table plus an up() hook that ALTERs the table owned by
+ * Hooks_First_Table_Migration, mimicking a new migration shipped in a later
+ * plugin version that needs to evolve a pre-existing table's schema.
+ *
+ * @package PinkCrab\Perique\Migration
+ */
+
+namespace PinkCrab\Perique\Migration\Tests\Fixtures;
+
+use PinkCrab\Perique\Migration\Migration;
+use PinkCrab\Table_Builder\Schema;
+
+class Alter_First_Table_Via_Up_Migration extends Migration {
+
+	public const TABLE_NAME = 'alter_first_table_via_up_migration';
+
+	protected function table_name(): string {
+		return self::TABLE_NAME;
+	}
+
+	public function schema( Schema $schema_config ): void {
+		$schema_config->column( 'id' )->unsigned_int( 11 )->auto_increment();
+		$schema_config->index( 'id' )->primary();
+	}
+
+	public function up(): void {
+		global $wpdb;
+		$target = Hooks_First_Table_Migration::TABLE_NAME;
+
+		// Idempotency guard: only add the column if it's not there yet so
+		// re-activation is safe.
+		$column_exists = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND COLUMN_NAME = %s',
+				DB_NAME,
+				$target,
+				'email'
+			)
+		);
+		if ( (int) $column_exists === 0 ) {
+			$wpdb->query( "ALTER TABLE {$target} ADD COLUMN email VARCHAR(255) NULL" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+	}
+}

--- a/tests/Fixtures/Hooks_First_Table_Migration.php
+++ b/tests/Fixtures/Hooks_First_Table_Migration.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture for the "second migration alters first" integration scenario.
+ * A minimal table owned exclusively by the hooks integration test, so the
+ * ALTER in Alter_First_Table_Via_Up_Migration::up() can't leak DDL into
+ * other tests' expectations of the shared Simple_Table_Migration.
+ *
+ * @package PinkCrab\Perique\Migration
+ */
+
+namespace PinkCrab\Perique\Migration\Tests\Fixtures;
+
+use PinkCrab\Perique\Migration\Migration;
+use PinkCrab\Table_Builder\Schema;
+
+class Hooks_First_Table_Migration extends Migration {
+
+	public const TABLE_NAME = 'hooks_first_table_migration';
+
+	protected function table_name(): string {
+		return self::TABLE_NAME;
+	}
+
+	public function schema( Schema $schema_config ): void {
+		$schema_config->column( 'id' )->unsigned_int( 11 )->auto_increment();
+		$schema_config->index( 'id' )->primary();
+	}
+}

--- a/tests/Fixtures/Hooks_Recording_Kept_Migration.php
+++ b/tests/Fixtures/Hooks_Recording_Kept_Migration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture migration that records up()/down() calls like
+ * Hooks_Recording_Migration, but opts OUT of drop_on_deactivation /
+ * drop_on_uninstall so we can assert down() is NOT called when the
+ * migration is kept rather than dropped.
+ *
+ * @package PinkCrab\Perique\Migration
+ * @author Glynn Quelch glynn@pinkcrab.co.uk
+ */
+
+namespace PinkCrab\Perique\Migration\Tests\Fixtures;
+
+use PinkCrab\Perique\Migration\Migration;
+use PinkCrab\Table_Builder\Schema;
+
+class Hooks_Recording_Kept_Migration extends Migration {
+
+	public const TABLE_NAME = 'hooks_recording_kept_migration';
+
+	public static int $up_calls   = 0;
+	public static int $down_calls = 0;
+
+	public static function reset(): void {
+		self::$up_calls   = 0;
+		self::$down_calls = 0;
+	}
+
+	protected function table_name(): string {
+		return self::TABLE_NAME;
+	}
+
+	public function schema( Schema $schema_config ): void {
+		$schema_config->column( 'id' )->unsigned_int( 11 )->auto_increment();
+		$schema_config->index( 'id' )->primary();
+	}
+
+	public function drop_on_deactivation(): bool {
+		return false;
+	}
+
+	public function drop_on_uninstall(): bool {
+		return false;
+	}
+
+	public function up(): void {
+		++self::$up_calls;
+	}
+
+	public function down(): void {
+		++self::$down_calls;
+	}
+}

--- a/tests/Fixtures/Hooks_Recording_Migration.php
+++ b/tests/Fixtures/Hooks_Recording_Migration.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture migration that records when its up() and down() hooks fire, so
+ * tests can assert the framework calls them at the right lifecycle points.
+ *
+ * @package PinkCrab\Perique\Migration
+ * @author Glynn Quelch glynn@pinkcrab.co.uk
+ */
+
+namespace PinkCrab\Perique\Migration\Tests\Fixtures;
+
+use PinkCrab\Perique\Migration\Migration;
+use PinkCrab\Table_Builder\Schema;
+
+class Hooks_Recording_Migration extends Migration {
+
+	public const TABLE_NAME = 'hooks_recording_migration';
+
+	/**
+	 * Counts up() invocations across all instances of this class (including
+	 * ones instantiated separately by the DI container in different tests).
+	 *
+	 * @var int
+	 */
+	public static int $up_calls = 0;
+
+	/**
+	 * Counts down() invocations across all instances.
+	 *
+	 * @var int
+	 */
+	public static int $down_calls = 0;
+
+	public static function reset(): void {
+		self::$up_calls   = 0;
+		self::$down_calls = 0;
+	}
+
+	protected function table_name(): string {
+		return self::TABLE_NAME;
+	}
+
+	public function schema( Schema $schema_config ): void {
+		$schema_config->column( 'id' )->unsigned_int( 11 )->auto_increment();
+		$schema_config->index( 'id' )->primary();
+	}
+
+	public function drop_on_deactivation(): bool {
+		return true;
+	}
+
+	public function drop_on_uninstall(): bool {
+		return true;
+	}
+
+	public function up(): void {
+		++self::$up_calls;
+	}
+
+	public function down(): void {
+		++self::$down_calls;
+	}
+}

--- a/tests/Integration/Test_Hooks.php
+++ b/tests/Integration/Test_Hooks.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Integration tests for the up()/down() migration lifecycle hooks.
+ *
+ * @since 2.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace PinkCrab\Perique\Migration\Tests\Integration;
+
+use WP_UnitTestCase;
+use PinkCrab\Perique\Application\App_Factory;
+use PinkCrab\Plugin_Lifecycle\Plugin_Life_Cycle;
+use PinkCrab\Perique\Migration\Module\Perique_Migrations;
+use PinkCrab\Perique\Migration\Tests\Helpers\App_Helper_Trait;
+use PinkCrab\Perique\Migration\Tests\Fixtures\Hooks_First_Table_Migration;
+use PinkCrab\Perique\Migration\Tests\Fixtures\Hooks_Recording_Migration;
+use PinkCrab\Perique\Migration\Tests\Fixtures\Hooks_Recording_Kept_Migration;
+use PinkCrab\Perique\Migration\Tests\Fixtures\Alter_First_Table_Via_Up_Migration;
+
+class Test_Hooks extends WP_UnitTestCase {
+
+	use App_Helper_Trait;
+
+	public static $app_instance;
+	public static $wpdb;
+
+	public function setUp(): void {
+		parent::setUp();
+		self::$app_instance    = ( new App_Factory() )->default_setup();
+		$GLOBALS['wp_filter']  = array();
+		$GLOBALS['wp_actions'] = array();
+		self::$wpdb            = $GLOBALS['wpdb'];
+		self::$wpdb->suppress_errors( true );
+
+		// Fresh counters per test.
+		Hooks_Recording_Migration::reset();
+		Hooks_Recording_Kept_Migration::reset();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->unset_app_instance();
+		$GLOBALS['wp_actions'] = array();
+		$GLOBALS['wp_filter']  = array();
+		\delete_option( 'uninstall_plugins' );
+		self::$wpdb->suppress_errors( false );
+	}
+
+	/** @testdox [INT] Migration::up() fires once per migration on activation, after the table has been upserted. */
+	public function test_up_fires_on_activation(): void {
+		self::$app_instance
+			->module(
+				Plugin_Life_Cycle::class,
+				fn( Plugin_Life_Cycle $e) => $e->plugin_base_file( __FILE__ )
+			)
+			->module(
+				Perique_Migrations::class,
+				fn( Perique_Migrations $e) => $e
+					->set_migration_log_key( 'test_up_fires_on_activation' )
+					->add_migration( Hooks_Recording_Migration::class )
+			)
+			->boot();
+
+		\do_action( 'activate_' . ltrim( __FILE__, '/' ) );
+
+		$this->assertSame( 1, Hooks_Recording_Migration::$up_calls );
+		$this->assertSame( 0, Hooks_Recording_Migration::$down_calls );
+	}
+
+	/** @testdox [INT] Migration::down() fires on deactivation for migrations flagged drop_on_deactivation, and NOT for migrations that stay. */
+	public function test_down_fires_on_deactivation_only_for_dropped_migrations(): void {
+		self::$app_instance
+			->module(
+				Plugin_Life_Cycle::class,
+				fn( Plugin_Life_Cycle $e) => $e->plugin_base_file( __FILE__ )
+			)
+			->module(
+				Perique_Migrations::class,
+				fn( Perique_Migrations $e) => $e
+					->set_migration_log_key( 'test_down_fires_on_deactivation' )
+					->add_migration( Hooks_Recording_Migration::class )      // drops on deactivation
+					->add_migration( Hooks_Recording_Kept_Migration::class ) // kept
+			)
+			->boot();
+
+		\do_action( 'activate_' . ltrim( __FILE__, '/' ) );
+		\do_action( 'deactivate_' . ltrim( __FILE__, '/' ) );
+
+		$this->assertSame( 1, Hooks_Recording_Migration::$down_calls, 'down() should fire for a migration being dropped' );
+		$this->assertSame( 0, Hooks_Recording_Kept_Migration::$down_calls, 'down() must NOT fire for a migration that is kept' );
+	}
+
+	/** @testdox [INT] Migration::down() fires on uninstall for migrations flagged drop_on_uninstall, and NOT for migrations that stay. */
+	public function test_down_fires_on_uninstall_only_for_dropped_migrations(): void {
+		self::$app_instance
+			->module(
+				Plugin_Life_Cycle::class,
+				fn( Plugin_Life_Cycle $e) => $e->plugin_base_file( __FILE__ )
+			)
+			->module(
+				Perique_Migrations::class,
+				fn( Perique_Migrations $e) => $e
+					->set_migration_log_key( 'test_down_fires_on_uninstall' )
+					->add_migration( Hooks_Recording_Migration::class )      // drops on uninstall
+					->add_migration( Hooks_Recording_Kept_Migration::class ) // kept
+			)
+			->boot();
+
+		\do_action( 'activate_' . ltrim( __FILE__, '/' ) );
+
+		// Reset counters so we only see uninstall contribution.
+		Hooks_Recording_Migration::reset();
+		Hooks_Recording_Kept_Migration::reset();
+
+		// Invoke the registered uninstall callback directly (what WP does on uninstall).
+		$uninstall_hooks = \get_option( 'uninstall_plugins' );
+		$plugin_file     = ltrim( __FILE__, '/' );
+		if ( isset( $uninstall_hooks[ $plugin_file ] ) && is_callable( $uninstall_hooks[ $plugin_file ] ) ) {
+			\call_user_func( $uninstall_hooks[ $plugin_file ] );
+		} else {
+			$this->fail( 'No uninstall hook registered for ' . $plugin_file );
+		}
+
+		$this->assertSame( 1, Hooks_Recording_Migration::$down_calls, 'down() should fire for a migration being dropped on uninstall' );
+		$this->assertSame( 0, Hooks_Recording_Kept_Migration::$down_calls, 'down() must NOT fire for a migration that is kept on uninstall' );
+	}
+
+	/** @testdox [INT] A second migration can use up() to ALTER a table owned by an earlier migration — the canonical "new migration in a later plugin version" scenario. */
+	public function test_second_migration_up_alters_first_migration_table(): void {
+		self::$app_instance
+			->module(
+				Plugin_Life_Cycle::class,
+				fn( Plugin_Life_Cycle $e) => $e->plugin_base_file( __FILE__ )
+			)
+			->module(
+				Perique_Migrations::class,
+				fn( Perique_Migrations $e) => $e
+					->set_migration_log_key( 'test_second_migration_up_alters_first_table' )
+					->add_migration( Hooks_First_Table_Migration::class )
+					->add_migration( Alter_First_Table_Via_Up_Migration::class )
+			)
+			->boot();
+
+		\do_action( 'activate_' . ltrim( __FILE__, '/' ) );
+
+		$first_table = Hooks_First_Table_Migration::TABLE_NAME;
+		$columns     = self::$wpdb->get_results( "SHOW COLUMNS FROM {$first_table};" );
+		$names       = array_map( fn( $c) => $c->Field, $columns );
+
+		$this->assertContains( 'email', $names, 'Alter_First_Table_Via_Up_Migration::up() should have added an "email" column to the first migration\'s table.' );
+
+		// Tidy up the DDL so other tests don't inherit an altered table.
+		// ALTER is auto-committed by MySQL so WP's transaction rollback won't clean it.
+		self::$wpdb->query( "DROP TABLE IF EXISTS {$first_table}" );
+		self::$wpdb->query( 'DROP TABLE IF EXISTS ' . Alter_First_Table_Via_Up_Migration::TABLE_NAME );
+	}
+}


### PR DESCRIPTION
Problem: migrations had no way to run custom work alongside the declarative schema()/seed() flow. Issue #32 raised the need for something like this so that a later plugin version can ship a new Migration class that evolves an already-installed table (e.g. rename or add a column).

Changes:
- Migration::up() and Migration::down() are new no-op default methods. No-op so existing subclasses without overrides keep working unchanged.
- Activation::run() now calls up() on every registered migration AFTER upsert_tables() and BEFORE seed_tables(). up() fires on every activation, so overrides must be idempotent.
- Deactivation::run() calls down() on each migration where drop_on_deactivation() is true, before drop_tables(). Kept migrations are untouched.
- Uninstall::run() calls down() on each table being dropped, then wraps drop_tables() + remove_migration_log() in a try/finally so the log always clears even if the drops throw - core principle being that nothing prevents uninstall.

Tests:
- tests/Fixtures/Hooks_Recording_Migration + Hooks_Recording_Kept_Migration record up()/down() calls via static counters (reset in setUp).
- tests/Fixtures/Hooks_First_Table_Migration + Alter_First_Table_Via_Up_Migration model the 'second migration alters the first' scenario end to end (ALTER TABLE add column, guarded for idempotency).
- tests/Integration/Test_Hooks asserts up() fires on activation, down() fires only for dropped migrations on deactivate and on uninstall, and the ALTER scenario adds the expected column.

Suite: 19 tests, 59 assertions, green. phpstan level 8 and phpcs clean. Clover coverage held at 100% (159/159 elements).

Closes #33 